### PR TITLE
fix(123done): don't overwrite config.json; set $CONFIG_123DONE=./config-local.json

### DIFF
--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -30,7 +30,7 @@ cd fxa-oauth-console && npm i && cd ..
 
 cd fxa-profile-server && npm i && mkdir -p var/public/ && cd ..
 
-cd 123done && npm i && node ./scripts/gen_keys.js &&  cp config-local.json config.json && cd ..
+cd 123done && npm i && CONFIG_123DONE=./config-local.json node ./scripts/gen_keys.js && cd ..
 
 cd loop-server && npm i && cd ..
 

--- a/servers.json
+++ b/servers.json
@@ -85,6 +85,7 @@
       "cwd": "123done",
       "max_restarts": "1",
       "env": {
+        "CONFIG_123DONE": "./config-local.json",
         "NODE_ENV": "dev"
       }      
     },


### PR DESCRIPTION
This fixes an issue where, because `config.json` had been locally modified, a `git pull origin master` would refuse to continue, thus getting no update. This is a simpler way. (Depends on https://github.com/mozilla/123done/pull/137)

@vladikoff r?